### PR TITLE
make FieldSetRegistry make use of the interface

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -24,6 +24,11 @@
             <argument type="collection" />
         </service>
 
+        <!-- SearchConditionSerializer -->
+        <service id="rollerworks_search.condition_serializer" class="Rollerworks\Component\Search\SearchConditionSerializer">
+            <argument id="rollerworks_search.fieldset_registry" type="service" />
+        </service>
+
         <!-- SearchRegistry -->
         <service id="rollerworks_search.registry" class="%rollerworks_search.registry.class%">
             <argument type="collection">

--- a/src/FieldSetRegistry.php
+++ b/src/FieldSetRegistry.php
@@ -11,13 +11,15 @@
 
 namespace Rollerworks\Component\Search\Extension\Symfony\DependencyInjection;
 
+use Rollerworks\Component\Search\Exception\InvalidArgumentException;
 use Rollerworks\Component\Search\FieldSet;
+use Rollerworks\Component\Search\FieldSetRegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
-class FieldSetRegistry
+class FieldSetRegistry implements FieldSetRegistryInterface
 {
     /**
      * @var string[]
@@ -42,18 +44,12 @@ class FieldSetRegistry
     }
 
     /**
-     * Gets a FieldSet from the container.
-     *
-     * @param string $name
-     *
-     * @return FieldSet
-     *
-     * @throws \InvalidArgumentException
+     * {@inheritdoc}
      */
-    public function getFieldSet($name)
+    public function get($name)
     {
         if (!isset($this->serviceIds[$name])) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf(
                     'Unable to get FieldSet "%s", FieldSet does not seem to be registered in the Service Container.',
                     $name
@@ -62,5 +58,44 @@ class FieldSetRegistry
         }
 
         return $this->container->get($this->serviceIds[$name]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($name)
+    {
+        return isset($this->serviceIds[$name]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add(FieldSet $fieldSet)
+    {
+        $name = $fieldSet->getSetName();
+
+        if (isset($this->serviceIds[$name])) {
+            throw new InvalidArgumentException(sprintf('Unable to overwrite already registered FieldSet "%s".', $name));
+        }
+
+        if (!$fieldSet->isConfigLocked()) {
+            throw new InvalidArgumentException(sprintf('Unable to register none configuration-locked FieldSet "%s".', $name));
+        }
+
+        $serviceId = 'rollerworks_search.fieldset.late_registering.'.$name;
+
+        $this->serviceIds[$name] = $serviceId;
+        $this->container->set($serviceId, $fieldSet);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function all()
+    {
+        return $this->serviceIds;
     }
 }


### PR DESCRIPTION
                   
|Q            |A  |
|---          |---|
|Bug Fix?     |no |
|New Feature? |yes|
|BC Breaks?   |yes|
|Deprecations?|no |
|Fixed Tickets|   |
|License      |MIT|
                   
getFieldSet() is dropped in replacement of get() (provided by the interface).
